### PR TITLE
chore: release v2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "github-track-followers",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "github-track-followers",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "license": "MIT",
             "dependencies": {
                 "colors": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "github-track-followers",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "🔨 CLI to display GitHub profile followers",
     "license": "MIT",
     "author": {
@@ -15,7 +15,8 @@
         "prebuild": "rm -rf dist/ types/",
         "build": "tsc",
         "test": "vitest run",
-        "coverage": "vitest run --coverage"
+        "coverage": "vitest run --coverage",
+        "prepublishOnly": "npm run build"
     },
     "dependencies": {
         "colors": "^1.4.0",


### PR DESCRIPTION
Release after the TypeScript migration (adds type declarations + compiled dist, non-breaking → minor). Adds prepublishOnly build safeguard.